### PR TITLE
scanone.perm used to fail on >1 "sex" columns

### DIFF
--- a/R/scanone.perm.R
+++ b/R/scanone.perm.R
@@ -83,7 +83,7 @@ scanone.perm = function(pheno, pheno.col = 1, probs, K = K, addcovar, intcovar, 
            LETTERS[1:8], sep = "."), snps[X.snps,1]))
 
   # Get the sex of the samples and place the probs in the correct columns.
-  sex.col = grep("sex", colnames(addcovar), ignore.case = TRUE)
+  sex.col = grep("^sex", colnames(addcovar), ignore.case = TRUE)
   sex = as.numeric(factor(addcovar[,sex.col])) - 1
   females = which(sex == 0)
   males   = which(sex == 1)


### PR DESCRIPTION
scanone.perm fails on my data giving me error

```
  Error in probs[females, , X.snps] : subscript out of bounds
```

I believe the problem occurs when there is more that one column incl. "sex" (like "Age:SexM"). I suggest to replace line 86

```
sex.col = grep("sex", colnames(addcovar), ignore.case = TRUE)
```

by

```
sex.col = grep("^sex", colnames(addcovar), ignore.case = TRUE)
```

as in `scanone` or even better

```
sex.col = grep("sex", colnames(addcovar), ignore.case = TRUE)[1]
```
